### PR TITLE
prevent calling rails cache fetch when cache expiry period is blank

### DIFF
--- a/lib/patterns/calculation.rb
+++ b/lib/patterns/calculation.rb
@@ -21,8 +21,12 @@ module Patterns
     end
 
     def cached_result
-      Rails.cache.fetch(cache_key, expires_in: cache_expiry_period, force: cache_expiry_period.blank?) do
+      if cache_expiry_period.blank?
         result
+      else
+        Rails.cache.fetch(cache_key, expires_in: cache_expiry_period) do
+          result
+        end
       end
     end
 


### PR DESCRIPTION
Expected behaviour:
Not setting `cache_expiry_period` to anything should prevent any calls to cache store.

Actual behaviour:
When using Redis `:redis_cache_store`, it still makes SET requests to cache store and stores value for each calculation call.

Fix: Prevent calling `Rails.cache.fetch` when `cache_expiry_period` is blank to avoid this. Note that doing so makes setting `force: ` option useless, so it can be removed.