### PR TITLE
cache key consistency across multiple servers

### DIFF
--- a/lib/patterns/calculation.rb
+++ b/lib/patterns/calculation.rb
@@ -35,7 +35,15 @@ module Patterns
     end
 
     def cache_key
-      "#{self.class.name}_#{[subject, options].hash}"
+      "#{self.class.name}_#{hash_of(subject, options)}"
+    end
+
+    def self.hash_of(*args)
+      Digest::SHA1.hexdigest(args.map(&:to_s).join(':'))
+    end
+
+    def hash_of(*args)
+      self.class.hash_of(*args)
     end
 
     def cache_expiry_period


### PR DESCRIPTION
`.hash` method has inconsistent results across different servers / ruby processes (see [link](https://stackoverflow.com/questions/6536885/consistent-stringhash-based-only-on-the-strings-content)).

I suggest replacing it with consistent method : `Digest::SHA1.hexdigest`.