### PR TITLE
Add Patterns module to Rule and Ruleset class

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ gem "rails-patterns"
 Then `bundle install`
 
 ## Query
- 
+
 ### When to use it
 
-One should consider using query objects pattern when in need to perform complex querying on active record relation. 
-Usually one should avoid using scopes for such purpose. 
+One should consider using query objects pattern when in need to perform complex querying on active record relation.
+Usually one should avoid using scopes for such purpose.
 As a rule of thumb, if scope interacts with more than one column and/or joins in other tables, it should be moved to query object.
 Also whenever a chain of scopes is to be used, one should consider using query object too.
 Some more information on using query objects can be found in [this article](https://medium.com/@blazejkosmowski/essential-rubyonrails-patterns-part-2-query-objects-4b253f4f4539).
@@ -98,9 +98,9 @@ Service objects are also useful for handling processes involving multiple steps.
 * It is recommended for `#call` method to be the only public method of service object (besides state readers)
 * It is recommended to name service object classes after commands (e.g. `ActivateUser` instead of `UserActivation`)
 
-### Other 
+### Other
 
-A bit higher level of abstraction is provided by [business_process gem](https://github.com/Selleo/business_process). 
+A bit higher level of abstraction is provided by [business_process gem](https://github.com/Selleo/business_process).
 
 ### Examples
 
@@ -396,13 +396,13 @@ However, from the actual usage perspective, it usually easier to conceptually de
 #### Declaration
 
 ```ruby
-class OrderIsSentRule < Rule
+class OrderIsSentRule < Patterns::Rule
   def satisfied?
     subject.sent?
   end
 end
 
-class OrderIsPaidRule < Rule
+class OrderIsPaidRule < Patterns::Rule
   def satisfied?
     subject.paid?
   end
@@ -412,7 +412,7 @@ class OrderIsPaidRule < Rule
   end
 end
 
-OrderCompletedNotificationRuleset = Class.new(Ruleset)
+OrderCompletedNotificationRuleset = Class.new(Patterns::Ruleset)
 OrderCompletedNotificationRuleset.
   add_rule(:order_is_sent_rule).
   add_rule(:order_is_paid_rule)

--- a/lib/patterns/rule.rb
+++ b/lib/patterns/rule.rb
@@ -1,25 +1,27 @@
-class Rule
-  def initialize(subject)
-    @subject = subject
+module Patterns
+  class Rule
+    def initialize(subject)
+      @subject = subject
+    end
+
+    def satisfied?
+      raise NotImplementedError
+    end
+
+    def not_applicable?
+      false
+    end
+
+    def applicable?
+      !not_applicable?
+    end
+
+    def forceable?
+      true
+    end
+
+    private
+
+    attr_reader :subject
   end
-
-  def satisfied?
-    raise NotImplementedError
-  end
-
-  def not_applicable?
-    false
-  end
-
-  def applicable?
-    !not_applicable?
-  end
-
-  def forceable?
-    true
-  end
-
-  private
-
-  attr_reader :subject
 end

--- a/lib/patterns/ruleset.rb
+++ b/lib/patterns/ruleset.rb
@@ -1,69 +1,71 @@
-class Ruleset
-  class EmptyRuleset < StandardError; end
+module Patterns
+  class Ruleset
+    class EmptyRuleset < StandardError; end
 
-  class << self
-    attr_accessor :rule_names
-  end
-
-  def self.rules
-    (rule_names || []).map do |rule_name|
-      rule_name.to_s.classify.constantize
+    class << self
+      attr_accessor :rule_names
     end
-  end
 
-  def self.add_rule(rule_name)
-    self.rule_names ||= []
-    self.rule_names << rule_name.to_sym
-    self
-  end
-
-  def initialize(subject = nil)
-    raise EmptyRuleset if self.class.rules.empty?
-
-    @rules = self.class.rules.map { |rule| rule.new(subject) }
-  end
-
-  def satisfied?(force: false)
-    rules.all? do |rule|
-      rule.satisfied? ||
-        rule.not_applicable? ||
-        (force && rule.forceable?)
-    end
-  end
-
-  def not_satisfied?
-    !satisfied?
-  end
-
-  def applicable?
-    !not_applicable?
-  end
-
-  def not_applicable?
-    rules.all?(&:not_applicable?)
-  end
-
-  def forceable?
-    rules.all? do |rule|
-      rule.forceable? ||
-        rule.not_applicable? ||
-        rule.satisfied?
-    end
-  end
-
-  def each(&block)
-    return enum_for(:each) unless block_given?
-
-    rules.each do |rule_or_ruleset|
-      if rule_or_ruleset.is_a?(Ruleset)
-        rule_or_ruleset.each(&block)
-      else
-        yield rule_or_ruleset
+    def self.rules
+      (rule_names || []).map do |rule_name|
+        rule_name.to_s.classify.constantize
       end
     end
+
+    def self.add_rule(rule_name)
+      self.rule_names ||= []
+      self.rule_names << rule_name.to_sym
+      self
+    end
+
+    def initialize(subject = nil)
+      raise EmptyRuleset if self.class.rules.empty?
+
+      @rules = self.class.rules.map { |rule| rule.new(subject) }
+    end
+
+    def satisfied?(force: false)
+      rules.all? do |rule|
+        rule.satisfied? ||
+          rule.not_applicable? ||
+          (force && rule.forceable?)
+      end
+    end
+
+    def not_satisfied?
+      !satisfied?
+    end
+
+    def applicable?
+      !not_applicable?
+    end
+
+    def not_applicable?
+      rules.all?(&:not_applicable?)
+    end
+
+    def forceable?
+      rules.all? do |rule|
+        rule.forceable? ||
+          rule.not_applicable? ||
+          rule.satisfied?
+      end
+    end
+
+    def each(&block)
+      return enum_for(:each) unless block_given?
+
+      rules.each do |rule_or_ruleset|
+        if rule_or_ruleset.is_a?(Ruleset)
+          rule_or_ruleset.each(&block)
+        else
+          yield rule_or_ruleset
+        end
+      end
+    end
+
+    private
+
+    attr_reader :rules
   end
-
-  private
-
-  attr_reader :rules
 end

--- a/lib/patterns/strong_ruleset.rb
+++ b/lib/patterns/strong_ruleset.rb
@@ -1,19 +1,21 @@
 # StrongRuleset is not satisfied and not forceable if any of rules is not applicable
 
-class StrongRuleset < Ruleset
-  def satisfied?(force: false)
-    rules.all? do |rule|
-      (rule.applicable? && rule.satisfied?) || (force && rule.forceable?)
+module Patterns
+  class StrongRuleset < Ruleset
+    def satisfied?(force: false)
+      rules.all? do |rule|
+        (rule.applicable? && rule.satisfied?) || (force && rule.forceable?)
+      end
     end
-  end
 
-  def not_applicable?
-    rules.any?(&:not_applicable?)
-  end
+    def not_applicable?
+      rules.any?(&:not_applicable?)
+    end
 
-  def forceable?
-    rules.all? do |rule|
-      (rule.applicable? && rule.forceable?) || rule.satisfied?
+    def forceable?
+      rules.all? do |rule|
+        (rule.applicable? && rule.forceable?) || rule.satisfied?
+      end
     end
   end
 end

--- a/spec/patterns/rule_spec.rb
+++ b/spec/patterns/rule_spec.rb
@@ -1,18 +1,18 @@
-RSpec.describe Rule do
+RSpec.describe Patterns::Rule do
   after(:each) do
     Object.send(:remove_const, :CustomRule) if defined?(CustomRule)
   end
 
   it 'requires subject as the first argument' do
-    CustomRule = Class.new(Rule)
+    CustomRule = Class.new(Patterns::Rule)
 
     expect { CustomRule.new }.to raise_error ArgumentError
     expect { CustomRule.new(Object.new) }.not_to raise_error
   end
 
   it 'requires #satisfied? method to be defined' do
-    InvalidCustomRule = Class.new(Rule)
-    CustomRule = Class.new(Rule) do
+    InvalidCustomRule = Class.new(Patterns::Rule)
+    CustomRule = Class.new(Patterns::Rule) do
       def satisfied?
         true
       end
@@ -27,7 +27,7 @@ RSpec.describe Rule do
       it 'returns true' do
         article = OpenStruct.new('published?' => true, 'deleted?' => false)
 
-        ArticleIsPublishedRule = Class.new(Rule) do
+        ArticleIsPublishedRule = Class.new(Patterns::Rule) do
           def satisfied?
             subject.published?
           end

--- a/spec/patterns/ruleset_spec.rb
+++ b/spec/patterns/ruleset_spec.rb
@@ -1,8 +1,8 @@
-RSpec.describe Ruleset do
+RSpec.describe Patterns::Ruleset do
   context 'when empty ruleset is initialized' do
     it 'raises an error' do
-      empty_ruleset_klass = Class.new(Ruleset)
-      custom_ruleset_klass = Class.new(Ruleset)
+      empty_ruleset_klass = Class.new(Patterns::Ruleset)
+      custom_ruleset_klass = Class.new(Patterns::Ruleset)
       subject = double
 
       with_mocked_rules do |rules|
@@ -12,7 +12,7 @@ RSpec.describe Ruleset do
         expect { custom_ruleset_klass.new(subject) }.not_to raise_error
       end
 
-      expect { empty_ruleset_klass.new(subject) }.to raise_error Ruleset::EmptyRuleset
+      expect { empty_ruleset_klass.new(subject) }.to raise_error Patterns::Ruleset::EmptyRuleset
     end
   end
 
@@ -24,7 +24,7 @@ RSpec.describe Ruleset do
           rules << mock_rule(:rule_1, is_forceable: true)
           rules << mock_rule(:rule_2, is_forceable: true)
 
-          custom_ruleset_klass = Class.new(Ruleset)
+          custom_ruleset_klass = Class.new(Patterns::Ruleset)
           custom_ruleset_klass.add_rule(:rule_1)
           custom_ruleset_klass.add_rule(:rule_2)
 
@@ -40,7 +40,7 @@ RSpec.describe Ruleset do
           rules << mock_rule(:rule_1, is_forceable: false, is_satisfied: false, is_applicable: true)
           rules << mock_rule(:rule_2, is_forceable: true)
 
-          custom_ruleset_klass = Class.new(Ruleset)
+          custom_ruleset_klass = Class.new(Patterns::Ruleset)
           custom_ruleset_klass.add_rule(:rule_1)
           custom_ruleset_klass.add_rule(:rule_2)
 
@@ -60,7 +60,7 @@ RSpec.describe Ruleset do
             )
             rules << mock_rule(:rule_2, is_forceable: true)
 
-            custom_ruleset_klass = Class.new(Ruleset)
+            custom_ruleset_klass = Class.new(Patterns::Ruleset)
             custom_ruleset_klass.add_rule(:rule_1)
             custom_ruleset_klass.add_rule(:rule_2)
 
@@ -81,7 +81,7 @@ RSpec.describe Ruleset do
             )
             rules << mock_rule(:rule_2, is_forceable: true)
 
-            custom_ruleset_klass = Class.new(Ruleset)
+            custom_ruleset_klass = Class.new(Patterns::Ruleset)
             custom_ruleset_klass.add_rule(:rule_1)
             custom_ruleset_klass.add_rule(:rule_2)
 
@@ -100,7 +100,7 @@ RSpec.describe Ruleset do
           rules << mock_rule(:rule_1, is_applicable: false)
           rules << mock_rule(:rule_2, is_applicable: false)
 
-          custom_ruleset_klass = Class.new(Ruleset)
+          custom_ruleset_klass = Class.new(Patterns::Ruleset)
           custom_ruleset_klass.add_rule(:rule_1)
           custom_ruleset_klass.add_rule(:rule_2)
 
@@ -116,7 +116,7 @@ RSpec.describe Ruleset do
           rules << mock_rule(:rule_1, is_applicable: false)
           rules << mock_rule(:rule_2, is_applicable: true)
 
-          custom_ruleset_klass = Class.new(Ruleset)
+          custom_ruleset_klass = Class.new(Patterns::Ruleset)
           custom_ruleset_klass.add_rule(:rule_1)
           custom_ruleset_klass.add_rule(:rule_2)
 
@@ -134,7 +134,7 @@ RSpec.describe Ruleset do
           rules << mock_rule(:rule_1)
           rules << mock_rule(:rule_2)
 
-          custom_ruleset_klass = Class.new(Ruleset)
+          custom_ruleset_klass = Class.new(Patterns::Ruleset)
           custom_ruleset_klass.add_rule(:rule_1)
           custom_ruleset_klass.add_rule(:rule_2)
 
@@ -150,7 +150,7 @@ RSpec.describe Ruleset do
           rules << mock_rule(:rule_1)
           rules << mock_rule(:rule_2, is_satisfied: false)
 
-          custom_ruleset_klass = Class.new(Ruleset)
+          custom_ruleset_klass = Class.new(Patterns::Ruleset)
           custom_ruleset_klass.add_rule(:rule_1)
           custom_ruleset_klass.add_rule(:rule_2)
 
@@ -165,7 +165,7 @@ RSpec.describe Ruleset do
             rules << mock_rule(:rule_1)
             rules << mock_rule(:rule_2, is_satisfied: false, is_applicable: false)
 
-            custom_ruleset_klass = Class.new(Ruleset)
+            custom_ruleset_klass = Class.new(Patterns::Ruleset)
             custom_ruleset_klass.add_rule(:rule_1)
             custom_ruleset_klass.add_rule(:rule_2)
 
@@ -182,7 +182,7 @@ RSpec.describe Ruleset do
               rules << mock_rule(:rule_1)
               rules << mock_rule(:rule_2, is_satisfied: false, is_forceable: true)
 
-              custom_ruleset_klass = Class.new(Ruleset)
+              custom_ruleset_klass = Class.new(Patterns::Ruleset)
               custom_ruleset_klass.add_rule(:rule_1)
               custom_ruleset_klass.add_rule(:rule_2)
 
@@ -198,7 +198,7 @@ RSpec.describe Ruleset do
               rules << mock_rule(:rule_1)
               rules << mock_rule(:rule_2, is_satisfied: false, is_forceable: false)
 
-              custom_ruleset_klass = Class.new(Ruleset)
+              custom_ruleset_klass = Class.new(Patterns::Ruleset)
               custom_ruleset_klass.add_rule(:rule_1)
               custom_ruleset_klass.add_rule(:rule_2)
 
@@ -216,10 +216,10 @@ RSpec.describe Ruleset do
         rules << (_, rule_1 = mock_rule(:rule_1))
         rules << (_, rule_2 = mock_rule(:rule_2))
         rules << (_, rule_3 = mock_rule(:rule_3))
-        custom_ruleset_klass_1 = Class.new(Ruleset)
+        custom_ruleset_klass_1 = Class.new(Patterns::Ruleset)
         custom_ruleset_klass_1.add_rule(:rule_1)
         custom_ruleset_klass_1.add_rule(:rule_2)
-        Ruleset2 = Class.new(Ruleset)
+        Ruleset2 = Class.new(Patterns::Ruleset)
         Ruleset2.add_rule(:rule_3)
         custom_ruleset_klass_1.add_rule(:ruleset_2)
 
@@ -235,7 +235,7 @@ RSpec.describe Ruleset do
   private
 
   def mock_rule(rule_name, is_applicable: true, is_satisfied: true, is_forceable: true)
-    klass = Object.const_set(rule_name.to_s.classify, Class.new(Rule))
+    klass = Object.const_set(rule_name.to_s.classify, Class.new(Patterns::Rule))
     rule = double(
       not_applicable?: !is_applicable,
       satisfied?: is_satisfied,

--- a/spec/patterns/strong_ruleset_spec.rb
+++ b/spec/patterns/strong_ruleset_spec.rb
@@ -1,7 +1,7 @@
-RSpec.describe StrongRuleset do
+RSpec.describe Patterns::StrongRuleset do
   it 'inherites from Ruleset' do
-    custom_strong_ruleset_klass = Class.new(StrongRuleset)
-    expect(custom_strong_ruleset_klass.ancestors).to include Ruleset
+    custom_strong_ruleset_klass = Class.new(Patterns::StrongRuleset)
+    expect(custom_strong_ruleset_klass.ancestors).to include Patterns::Ruleset
   end
 
   context 'when any of rules is not applicable' do
@@ -11,7 +11,7 @@ RSpec.describe StrongRuleset do
         rules << mock_rule(:rule_1, is_applicable: false)
         rules << mock_rule(:rule_2)
 
-        custom_ruleset_klass = Class.new(StrongRuleset)
+        custom_ruleset_klass = Class.new(Patterns::StrongRuleset)
         custom_ruleset_klass.add_rule(:rule_1)
         custom_ruleset_klass.add_rule(:rule_2)
 
@@ -26,7 +26,7 @@ RSpec.describe StrongRuleset do
           rules << mock_rule(:rule_1, is_applicable: false, is_satisfied: false)
           rules << mock_rule(:rule_2)
 
-          custom_ruleset_klass = Class.new(StrongRuleset)
+          custom_ruleset_klass = Class.new(Patterns::StrongRuleset)
           custom_ruleset_klass.add_rule(:rule_1)
           custom_ruleset_klass.add_rule(:rule_2)
 
@@ -41,7 +41,7 @@ RSpec.describe StrongRuleset do
         rules << mock_rule(:rule_1, is_applicable: false)
         rules << mock_rule(:rule_2)
 
-        custom_ruleset_klass = Class.new(StrongRuleset)
+        custom_ruleset_klass = Class.new(Patterns::StrongRuleset)
         custom_ruleset_klass.add_rule(:rule_1)
         custom_ruleset_klass.add_rule(:rule_2)
 
@@ -53,7 +53,7 @@ RSpec.describe StrongRuleset do
   private
 
   def mock_rule(rule_name, is_applicable: true, is_satisfied: true, is_forceable: true)
-    klass = Object.const_set(rule_name.to_s.classify, Class.new(Rule))
+    klass = Object.const_set(rule_name.to_s.classify, Class.new(Patterns::Rule))
     rule = double(
       not_applicable?: !is_applicable,
       applicable?: is_applicable,


### PR DESCRIPTION
## Why
`Rule` and `Ruleset` classes are in the `patterns` directory but they don't have `Patterns` module.

## Done
Add `Patterns` module to all rule classes.