### PR TITLE
AM - Allow Ruleset to be empty (without rules) and be satisfied in that case

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Use it when:
 * Override `#not_applicable?` when method is applicable only under some specific conditions. Is `false` by default.
 * Rule requires a subject as first argument.
 * Multiple rules and rulesets can be combined into new ruleset as both share same interface and can be used interchangeably (composite pattern).
+* By default empty ruleset is satisfied.
 
 #### Forcing rules
 

--- a/lib/patterns/ruleset.rb
+++ b/lib/patterns/ruleset.rb
@@ -1,7 +1,5 @@
 module Patterns
   class Ruleset
-    class EmptyRuleset < StandardError; end
-
     class << self
       attr_accessor :rule_names
     end
@@ -19,8 +17,6 @@ module Patterns
     end
 
     def initialize(subject = nil)
-      raise EmptyRuleset if self.class.rules.empty?
-
       @rules = self.class.rules.map { |rule| rule.new(subject) }
     end
 

--- a/spec/patterns/ruleset_spec.rb
+++ b/spec/patterns/ruleset_spec.rb
@@ -1,21 +1,4 @@
 RSpec.describe Patterns::Ruleset do
-  context 'when empty ruleset is initialized' do
-    it 'raises an error' do
-      empty_ruleset_klass = Class.new(Patterns::Ruleset)
-      custom_ruleset_klass = Class.new(Patterns::Ruleset)
-      subject = double
-
-      with_mocked_rules do |rules|
-        rules << mock_rule(:rule_1)
-        custom_ruleset_klass.add_rule(:rule_1)
-
-        expect { custom_ruleset_klass.new(subject) }.not_to raise_error
-      end
-
-      expect { empty_ruleset_klass.new(subject) }.to raise_error Patterns::Ruleset::EmptyRuleset
-    end
-  end
-
   describe '#forceable?' do
     context 'all rules are forceable' do
       it 'returns true' do
@@ -205,6 +188,18 @@ RSpec.describe Patterns::Ruleset do
               expect(custom_ruleset_klass.new(subject).satisfied?(force: true)).to eq false
             end
           end
+        end
+      end
+    end
+
+    context 'ruleset has no rules' do
+      it 'returns true' do
+        with_mocked_rules do |_rules|
+          subject = double
+
+          custom_ruleset_klass = Class.new(Patterns::Ruleset)
+
+          expect(custom_ruleset_klass.new(subject).satisfied?).to eq true
         end
       end
     end


### PR DESCRIPTION
We want to be able to have empty ruleset (without rules) and for this case, method `#satisfied?` should return `true`. So empty ruleset should be satisfied.